### PR TITLE
fix: Make sure that the user is only once in Permit table

### DIFF
--- a/database/verification.py
+++ b/database/verification.py
@@ -111,7 +111,7 @@ class ValidPersonDB(database.base):
 
     def save_verified(self, discord_id: str) -> None:
         """"Inserts login with discord name into database"""
-        session.add(PermitDB(login=self.login, discord_ID=discord_id))
+        PermitDB.add_user(login=self.login, discord_ID=discord_id)
         self.status = 0
         session.commit()
 

--- a/features/verification.py
+++ b/features/verification.py
@@ -268,7 +268,14 @@ class Verification(BaseFeature):
             await member.add_roles(verify)
             await member.add_roles(year)
 
-            new_user.save_verified(inter.user.id)
+            try:
+                new_user.save_verified(inter.user.id)
+            except Exception:
+                return await self.log_verify_fail(
+                    inter,
+                    "Verify (with code) (User already verified?)",
+                    str({"login": login, "year": new_user.year})
+                )
 
             verify_success_msg = Messages.verify_verify_success(user=inter.user.id)
             try:


### PR DESCRIPTION
## PR type
- [x] Bug Fix
<!-- check all applicable -->
<!--
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
-->

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->
Before this fix, it was somehow possible for a user to be multiple times in a DB, which resulted in DB exception. TBH I am still not sure how they could end up in such a state, but I would guess that they double-clicked on a button because it was seemingly unresponsive or they have already been on the server and some mod linked their account.

## Related Issue(s)
- Closes #797
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [x] Restart bot
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config

- [ ] Reload cog(s) [name(s)]
-->

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
