### PR TITLE
fix: datetime.utcnow() deprecated

### DIFF
--- a/cogs/autopin.py
+++ b/cogs/autopin.py
@@ -20,7 +20,7 @@ from permissions import permission_check, room_check
 class AutoPin(Base, commands.Cog):
     def __init__(self, bot):
         super().__init__()
-        self.warning_time = datetime.datetime.utcnow() - datetime.timedelta(
+        self.warning_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
             minutes=self.config.autopin_warning_cooldown
         )
         self.bot = bot
@@ -213,7 +213,7 @@ class AutoPin(Base, commands.Cog):
                 # prevent spamming max_pins_error message in channel
                 pin_count = await channel.pins()
                 if len(pin_count) == 50:
-                    now = datetime.datetime.utcnow()
+                    now = datetime.datetime.now(datetime.timezone.utc)
                     cooldown = datetime.timedelta(minutes=self.config.autopin_warning_cooldown)
                     if self.warning_time + cooldown < now:
                         await channel.send(

--- a/cogs/streamlinks.py
+++ b/cogs/streamlinks.py
@@ -3,7 +3,7 @@ Cog implementing streamlinks system. List streams for a subject.
 """
 
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Union
 
 import disnake
@@ -138,7 +138,7 @@ class StreamLinks(Base, commands.Cog):
             link_data['upload_date'] = datetime.strptime(date, '%d.%m.%Y')
         else:
             if link_data['upload_date'] is None:
-                link_data['upload_date'] = datetime.utcnow()
+                link_data['upload_date'] = datetime.now(timezone.utc)
 
         StreamLinkDB.create(
             subject.lower(),
@@ -230,7 +230,7 @@ class StreamLinks(Base, commands.Cog):
         stream.merge()
 
         utils.add_author_footer(embed, inter.author)
-        embed.timestamp = datetime.utcnow()
+        embed.timestamp = datetime.now(timezone.utc)
         channel = self.bot.get_channel(self.config.log_channel)
         await channel.send(embed=embed)
         await inter.edit_original_response(content=Messages.streamlinks_update_success)
@@ -265,7 +265,7 @@ class StreamLinks(Base, commands.Cog):
         embed.add_field(name="Od", value=stream.member_name)
         embed.add_field(name="Popis", value=stream.description[:1024])
         embed.add_field(name="Odkaz", value=f"[link]({stream.link})", inline=False)
-        embed.timestamp = datetime.utcnow()
+        embed.timestamp = datetime.now(timezone.utc)
         channel = self.bot.get_channel(self.config.log_channel)
         await channel.send(embed=embed)
 
@@ -336,7 +336,7 @@ class StreamLinks(Base, commands.Cog):
         )
         embed.add_field(name="Odkaz", value=f"[Link]({streamlink.link})", inline=False)
         embed.add_field(name="Popis", value=streamlink.description[:1024], inline=False)
-        embed.timestamp = datetime.utcnow()
+        embed.timestamp = datetime.now(timezone.utc)
         utils.add_author_footer(embed, author, additional_text=[
                                 f"[{streamlink.subject.upper()}] Page: {current_pos} / {links_count}"
                                 f" (#{streamlink.id})"])

--- a/features/presence.py
+++ b/features/presence.py
@@ -14,7 +14,7 @@ class Presence(BaseFeature):
         self.git = Git()
 
         self.activity = disnake.Game(
-            start=datetime.datetime.utcnow(),
+            start=datetime.datetime.now(datetime.timezone.utc),
             name=config.default_prefix + 'god'
             f' | Running hash {self.git.short_hash()}')
 


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Refactor/Enhancement

## Description
As recommended here https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
datetime.utcnow() will be deprecated in future versions

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot


## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
