### PR TITLE
feat(EmbedView): add option show page numbers in embed footer

### DIFF
--- a/buttons/embed.py
+++ b/buttons/embed.py
@@ -25,7 +25,8 @@ class EmbedView(BaseView):
         end_arrow: bool = True,
         page_source: LeaderboardPageSource = None,
         timeout: int = 300,
-        page: int = 1
+        page: int = 1,
+        show_page: bool = False,
     ):
         """Embed pagination view
 
@@ -38,6 +39,7 @@ class EmbedView(BaseView):
         param LeaderboardPageSource page_source: Use for long leaderboards, embeds should contain one embed
         param int timeout: Seconds until disabling interaction, use None for always enabled
         param int page: Starting page
+        param bool show_page: Show page number at the bottom of embed, e.g.: 2/4
         """
         self.page = page
         self.author = author
@@ -54,6 +56,8 @@ class EmbedView(BaseView):
         super().__init__(timeout=timeout)
         if self.max_page <= 1:
             return
+        if show_page:
+            self.add_page_numbers()
         self.add_item(
             disnake.ui.Button(
                 emoji="⏪",
@@ -121,6 +125,11 @@ class EmbedView(BaseView):
             # we are trying to add new button to already filled row
             raise ViewRowFull
         super().add_item(item)
+
+    def add_page_numbers(self):
+        """Set footers with page numbers for each embed in list"""
+        for page, embed in enumerate(self.embeds):
+            utils.add_author_footer(embed, self.author, additional_text=[f"Page {page+1}/{self.max_page}"])
 
     async def interaction_check(self, interaction: disnake.MessageInteraction) -> Optional[bool]:
         if interaction.data.custom_id == "embed:lock":


### PR DESCRIPTION
## PR type
- [x] New Feature
<!-- check all applicable -->
<!--
- [ ] Refactor/Enhancement
- [ ] New Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
-->

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->
Adding an option to automatically add a footer with the page number (e.g.: 2/4) in EmbedView by simply adding a `show_page=True` argument when initialising the class.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
- [x] PR was tested - tested on reviews, but it is not used there as they require additional text in embed with ID of the review


## Post deployment
- [x] Restart bot
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
![image](https://github.com/vutfitdiscord/rubbergod/assets/43444182/5b692a82-316b-487f-943b-3e622e7dbd4c)
