### PR TITLE
feat(verify): use new API for verification

### DIFF
--- a/config/app_config.py
+++ b/config/app_config.py
@@ -57,6 +57,7 @@ class Config:
     verification_role_id: int = get_attr(toml_dict, "verification", "role_id")
     verification_host_id: int = get_attr(toml_dict, "verification", "host_id")
     db_pull_merlin_key_path: str = get_attr(toml_dict, "verification", "db_pull_merlin_key_path")
+    vut_api_key: str = get_attr(toml_dict, "verification", "vut_api_key")
 
     # Verification email sender settings
     email_name: str = get_attr(toml_dict, "email", "name")

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -15,6 +15,7 @@ role = ''
 role_id = 591349196267716608
 host_id = 603673568051462144
 db_pull_merlin_key_path = '/root/.ssh/etc_passwd'
+vut_api_key = ''
 
 [email]
 name = 'toasterrubbergod@gmail.com'

--- a/config/messages.py
+++ b/config/messages.py
@@ -235,7 +235,7 @@ class Messages(metaclass=Formatable):
 
     # VERIFY
     verify_brief = "Ověření studenta pro přístup na server."
-    verify_login_parameter = "Přihlašovací FIT login (nebo MUNI UČO). FIT login ve formátu `xlogin00`"
+    verify_login_parameter = "Přihlašovací FIT login (`xlogin00`), osobní 6 místné VUT číslo nebo MUNI UČO."
     verify_already_verified = "{user} Už jsi byl verifikován " \
                               "({admin} pls)."
     verify_send_dumbshit = "{user} Tvůj login. {emote}"
@@ -261,7 +261,6 @@ class Messages(metaclass=Formatable):
 
     verify_verify_not_found = "{user} Login nenalezen nebo jsi neprošel krokem `/verify`. Přečti si prosím <#591386755547136020>. ({admin} pls)."
     verify_verify_wrong_code = "Špatný kód."
-    verify_unknown_login = "{user} Tvůj login nebyl nalezen v databázi. ({admin} pls)"
     verify_step_done = "{user} Tímto krokem jsi už prošel. ({admin} pls)"
     verify_invalid_channel = "Tento příkaz je možné spustit pouze v DMs nebo na VUT FIT serveru."
     invalid_login = "{user} Neplatný login. Přečti si prosím <#591386755547136020>. ({admin} pls)"

--- a/features/verification.py
+++ b/features/verification.py
@@ -91,22 +91,10 @@ class Verification(BaseFeature):
                 await self.send_xlogin_info(inter)
                 return False
 
-            if login[0] == "x":
+            user = await self.helper.check_api(login)
+            if user is not None:
                 # VUT
-                # Check if the login we got is in the database
-                user = ValidPersonDB.get_user_by_login(login)
-
-                if user is None:
-                    msg = Messages.verify_unknown_login(
-                        user=inter.user.id,
-                        admin=config.admin_ids[0],
-                    )
-                    await inter.edit_original_response(content=msg)
-                    await inter.followup.send(content=msg)
-                    await self.log_verify_fail(
-                        inter, "getcode (xlogin) - Unknown login", str({"login": login})
-                    )
-                elif user.status != VerifyStatus.Unverified.value:
+                if user.status != VerifyStatus.Unverified.value:
                     if user.status == VerifyStatus.InProcess.value:
                         await self.gen_code_and_send_mail(inter, user, "stud.fit.vutbr.cz", dry_run=True)
                         return True
@@ -207,6 +195,8 @@ class Verification(BaseFeature):
                 return "2MIT+" if year_value >= 2 else f"{year_value}MIT"
             elif year_parts[1] in ["DVI4", "DRH", "DITP", "DITP-EN"]:
                 return "Doktorand"
+        elif year_parts[0] == "employee":
+            return "Vyucujici/Zamestnanec FIT"
         elif year_parts[0] in [
             "FA", "FAST", "FAVU", "FCH", "FEKT", "FP", "FSI", "USI"
         ]:  # Other VUT faculties


### PR DESCRIPTION
## PR type
- [x] New Feature

## Description
Add call to the new VUT API during verification. This will allow us to have more reliable data and also improve other parts of bot based on this API. I haven't completely removed old parsing to keep the compatibility layer for some time. When we verify this works reliable enough we will remove old way of fetching logins. The new approach is using on demand fetch per user.

## After checks
<!-- check all applicable -->
- [x] PR was tested - tested including the whole verification
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [x] Change config - add API key to config -- already done
- [x] Restart bot
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

