### PR TITLE
Fix list of messages not working in threads

### DIFF
--- a/features/list_message_sender.py
+++ b/features/list_message_sender.py
@@ -51,7 +51,7 @@ def merge_messages(message_list: Iterable, max_msg_len: int):
 
 
 async def send_list_of_messages(
-        ctx: Union[disnake.TextChannel, commands.Context, disnake.ApplicationCommandInteraction],
+        ctx: Union[disnake.ApplicationCommandInteraction, commands.Context, disnake.abc.Messageable],
         message_list: Iterable,
         max_msg_len: int = 1900,
         ephemeral: bool = False
@@ -92,5 +92,5 @@ async def send_list_of_messages(
                 await ctx.channel.reply(message)
             else:
                 await ctx.channel.send(message)
-        elif isinstance(ctx, disnake.TextChannel):
+        elif isinstance(ctx, disnake.abc.Messageable):
             await ctx.send(message)


### PR DESCRIPTION
## PR type
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->
`send_list_of_messages()` didn't work in some channel types (threads, for example). This PR should fix it
as it allows any `Messageable` as a destination.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [x] Restart bot
- [ ] Reload cog(s) [name(s)]

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
