### PR TITLE
Timeout

### DIFF
--- a/database/timeout.py
+++ b/database/timeout.py
@@ -26,7 +26,8 @@ class TimeoutDB(database.base):
 
     @hybrid_property
     def is_active(self) -> bool:
-        return self.end > datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc).replace(tzinfo=None)   # can't compare timezone aware and unaware
+        return self.end > now
 
     @hybrid_property
     def length(self) -> timedelta:

--- a/features/error.py
+++ b/features/error.py
@@ -423,7 +423,7 @@ class ErrorLogger:
         if isinstance(error, commands.CommandOnCooldown):
             time = datetime.datetime.now() + datetime.timedelta(seconds=error.retry_after)
             retry_after = utils.get_discord_timestamp(time, style="Relative Time")
-            await ctx.send(Messages.spamming(user=ctx.author.id, time=retry_after))
+            await ctx.send(Messages.spamming(user=ctx.author.id, time=retry_after), ephemeral=True)
             return True
 
         if isinstance(error, commands.NoPrivateMessage):

--- a/features/timeout.py
+++ b/features/timeout.py
@@ -165,7 +165,7 @@ async def time_check(
         await inter.send(Messages.timeout_past_time, ephemeral=True)
         return True
 
-    if length.seconds < 30:
+    if length.total_seconds() < 30:
         await inter.send(Messages.timeout_too_short, ephemeral=True)
         return True
     return False


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
- property was usable by sqlalchemy but could not be used normally as it would raise compare naive and aware times
- missing ephemeral for command on cooldown

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot
