### PR TITLE
Ruff fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ repos:
   hooks:
     - id: ruff
       name: ruff
+      args: [--fix, --exit-non-zero-on-fix]
       description: This hook runs ruff linter.
     - id: ruff-format
       name: ruff-format

--- a/cogs/fitwide.py
+++ b/cogs/fitwide.py
@@ -27,7 +27,7 @@ CATEGORIES_NAMES = [
     "1. semestr", "2. semestr", "3. semestr", "4. semestr", "5. semestr",
     "zimni-volitelne", "letni-volitelne", "volitelne",
     "zimni magistersky semestr", "letni magistersky semestr",
-]  # fmt: off
+]  # fmt: skip
 
 
 class FitWide(Base, commands.Cog):

--- a/features/verification.py
+++ b/features/verification.py
@@ -22,9 +22,9 @@ MIT_SPECIALIZATIONS = [
     "MPV", "MSK", "NADE", "NBIO", "NGRI", "NNET", "NVIZ", "NCPS",
     "NSEC", "NEMB", "NHPC", "NISD", "NIDE", "NISY", "NMAL", "NMAT", "NSEN",
     "NVER", "NSPE", "MGH", "MITP-EN",
-]  # fmt: off
+]  # fmt: skip
 
-FACULTY_NAMES = ["FA", "FAST", "FAVU", "FCH", "FEKT", "FP", "FSI", "USI",]  # fmt: off
+FACULTY_NAMES = ["FA", "FAST", "FAVU", "FCH", "FEKT", "FP", "FSI", "USI",]  # fmt: skip
 
 
 class Verification(BaseFeature):


### PR DESCRIPTION
## PR type
- [x] Bug Fix


## Description
Add automatic fix for ruff linter.
change comments to turn off format from `fmt: off` to `fmt: skip`. The first option is used to turn off formatting until turned on with `fmt: on`, skip is used to skip only one line. The previous code skipped the whole file. See the docs: https://docs.astral.sh/ruff/formatter/#format-suppression

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

