### PR TITLE
ci: enable mypy in pre-commit ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 ci:
   autofix_prs: false
-  skip: [mypy]  # remove after https://github.com/vutfitdiscord/rubbergod/issues/952 is done
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## PR type
- [x] Refactor/Enhancement


## Description
Now that we have all mypy issues fixed we can enable the pre-commit check again to run on all files.

## Related Issue(s)
- Closes #952

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

