### PR TITLE
rename emoji commands

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -86,8 +86,8 @@ Cog for dynamically changing config.\
 Cog for managing server emojis. Download emojis and stickers. Get full size of emoji.\
 **Commands:**
 
-    - /emoji get_emojis
-    - /emoji get_emoji
+    - /emoji all
+    - /emoji get
 ---
 
 ### [Error](error/cog.py)

--- a/cogs/emoji/cog.py
+++ b/cogs/emoji/cog.py
@@ -50,7 +50,7 @@ class Emoji(Base, commands.Cog):
         await inter.response.defer(ephemeral=self.check.botroom_check(inter))
 
     @cooldowns.default_cooldown
-    @emoji.sub_command(name="get_emojis", description=MessagesCZ.get_emojis_brief)
+    @emoji.sub_command(name="all", description=MessagesCZ.emoji_all_brief)
     async def get_emojis(self, inter: disnake.ApplicationCommandInteraction):
         """Get all emojis from server"""
         if not os.path.exists("emojis.zip"):
@@ -58,7 +58,7 @@ class Emoji(Base, commands.Cog):
         await inter.send(file=disnake.File("emojis.zip"))
 
     @cooldowns.default_cooldown
-    @emoji.sub_command(name="get_emoji", description=MessagesCZ.get_emoji_brief)
+    @emoji.sub_command(name="get", description=MessagesCZ.emoji_get_brief)
     async def get_emoji(self, inter: disnake.ApplicationCommandInteraction, emoji: disnake.PartialEmoji):
         """Get emoji in full size"""
         await inter.send(emoji.url)

--- a/cogs/emoji/messages_cz.py
+++ b/cogs/emoji/messages_cz.py
@@ -2,6 +2,6 @@ from config.messages import Messages as GlobalMessages
 
 
 class MessagesCZ(GlobalMessages):
-    get_emojis_brief = "Pošle zip se všemi emoji a stickery ze serveru"
-    get_emoji_brief = "Zobrazí emoji v plné velikosti"
+    emoji_all_brief = "Pošle zip se všemi emoji a stickery ze serveru"
+    emoji_get_brief = "Zobrazí emoji v plné velikosti"
     not_emoji = "Neplatný formát emoji"


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Refactor/Enhancement

## Description
Rename emoji commands to simpler version. They were a lot similar and people got confused.

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot