### PR TITLE
traceback not ephemeral

### DIFF
--- a/buttons/error.py
+++ b/buttons/error.py
@@ -23,14 +23,14 @@ class ErrorView(BaseView):
         emoji="📄", label="Traceback", style=disnake.ButtonStyle.danger, custom_id="error:traceback"
     )
     async def traceback(self, button: disnake.ui.Button, inter: disnake.MessageInteraction) -> None:
-        await inter.response.defer(ephemeral=True)
+        await inter.response.defer()
         file = self.create_traceback_file(inter)
-        await inter.send(file=file)
+        await inter.send(file=file, ephemeral=True)
 
     @disnake.ui.button(
         emoji="📄", label="Traceback DM", style=disnake.ButtonStyle.danger, custom_id="error:traceback_dm"
     )
     async def traceback_dm(self, button: disnake.ui.Button, inter: disnake.MessageInteraction) -> None:
-        await inter.response.defer(ephemeral=True)
+        await inter.response.defer()
         file = self.create_traceback_file(inter)
         await inter.author.send(file=file, view=TrashView())


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
making interaction from buttons ephemeral does not make message ephemeral -> hence it's useless and needs to be with sending instead of defer

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot