### PR TITLE
remove mention in pick

### DIFF
--- a/cogs/random/cog.py
+++ b/cogs/random/cog.py
@@ -48,7 +48,7 @@ class Random(Base, commands.Cog):
             await inter.send(MessagesCZ.pick_empty)
             return
         option = disnake.utils.escape_mentions(random.choice(args_list))
-        await inter.send(f"{option} {inter.author.mention}", ephemeral=self.check.botroom_check(inter))
+        await inter.send(option, ephemeral=self.check.botroom_check(inter))
 
     @cooldowns.short_cooldown
     @commands.slash_command(name="flip", description=MessagesCZ.flip_brief)


### PR DESCRIPTION
## PR type
- [x] Refactor/Enhancement

## Description
remove mention in /pick command. It's unnecessary when the command implicitly tags the user, just makes it confusing when inputting user tags.

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Reload cog(s) [random]