### PR TITLE
remove blocking requests in gif.py

### DIFF
--- a/cogs/gif/messages_cz.py
+++ b/cogs/gif/messages_cz.py
@@ -5,4 +5,3 @@ class MessagesCZ(GlobalMessages):
     bonk_brief = "Bonk na uživatele"
     unsupported_image = "Tento avatar aktuálne není podporovaný <:sadcat:576171980118687754>"
     pet_brief = "Vytvoří gif z uživatele."
-    gif_req_error = "Nepodařilo se získat profilový obrázek uživatele."


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Refactor/Enhancement

## Description
wrong use of getting user profile picture made the command blocking with using requests. Now fixed

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Reload cog(s) gif