### PR TITLE
fix: config singleton pattern deletion

### DIFF
--- a/config/app_config.py
+++ b/config/app_config.py
@@ -38,6 +38,11 @@ class Config:
             cls.instance = super(Config, cls).__new__(cls)
         return cls.instance
 
+    @classmethod
+    def _del(cls):
+        if hasattr(cls, "instance"):
+            del cls.instance
+
     toml_dict: dict = toml.load("config/config.toml", _dict=dict)
 
     # Authorization
@@ -221,5 +226,5 @@ def config_get_keys() -> list:
 
 def load_config():
     global config
-    del config.instance
+    Config._del()
     config = Config()


### PR DESCRIPTION
## PR type
- [x] Bug Fix


## Description
Fix the exception that the config class has no attribute instance. I tried to delete the attribute in the instance instead of deleting it from the class itself.

## Related Issue(s)
Closes #1047

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [x] Restart bot