### PR TITLE
fix sending update to grillbot on selftimeout

### DIFF
--- a/cogs/timeout/features.py
+++ b/cogs/timeout/features.py
@@ -125,7 +125,7 @@ async def timeout_perms(
                 isself,
             )
 
-        if timeout and not isself:
+        if timeout:
             error = await send_to_grillbot(session, timeout, mode)
             if error:
                 await bot_dev_channel.send(error)
@@ -202,6 +202,9 @@ async def send_to_grillbot(
     Sending create/update timeout event or delete timeout event.
     """
     # if user got timeout from automod grillbot api expects user_id as mod_id
+    if timeout.isself:
+        return None
+
     mod_id = timeout.user_id if timeout.mod_id == "1" else timeout.mod_id
     if mode == "delete":
         try:


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
when using `/remove timeout` on selftimeouted user, the update goes to grillbot which should not happen.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot