### PR TITLE
fix: update year of users that are already in DB

### DIFF
--- a/features/verify_helper.py
+++ b/features/verify_helper.py
@@ -84,6 +84,11 @@ class VerifyHelper:
             )
             session.add(person)
             session.commit()
+        else:
+            relation = self._parse_relation(user)
+            if person.year != await relation:
+                person.year = relation
+                session.commit()
         return person
 
     async def check_api(self, id: str) -> ValidPersonDB | None:


### PR DESCRIPTION
## PR type
- [x] Bug Fix

## Description
Fix for new students who tried to verify before they were in DB. API didn't find them so the bot went to fallback with MUNI login. This is now causing issues because they are already in the DB with MUNI year, which is not correct. This fix should update the year if it has changed compared to the already saved version. Please note that this was not tested.

## Related Issue(s)
No GH issue

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->
