### PR TITLE
fix lottie sticker bookmark

### DIFF
--- a/cogs/bookmark/features.py
+++ b/cogs/bookmark/features.py
@@ -45,6 +45,7 @@ class Features:
 
         # create list of attachments
         upload_limit = False
+        lottie_sticker = False
         images = []
         files_attached = []
         if inter.message.attachments:
@@ -63,16 +64,23 @@ class Features:
 
         if inter.message.stickers:
             for sticker in inter.message.stickers:
+                if sticker.format is disnake.StickerFormatType.lottie:
+                    lottie_sticker = True
+                    continue
                 files_attached.append(await sticker.to_file())
 
         if len(content) > 1024:
             parts = split_to_parts(content, 1024)
             for msg in parts:
-                embed.add_field(name="Původní zpráva", value=msg, inline=False)
+                embed.add_field(name=MessagesCZ.original_message, value=msg, inline=False)
         else:
-            embed.add_field(name="Původní zpráva", value=content, inline=False)
+            embed.add_field(name=MessagesCZ.original_message, value=content, inline=False)
 
         if upload_limit:
-            embed.add_field(name="Poznámka", value=MessagesCZ.upload_limit, inline=False)
+            embed.add_field(name=MessagesCZ.bookmark_note, value=MessagesCZ.upload_limit, inline=False)
+
+        if lottie_sticker:
+            embed.add_field(name=MessagesCZ.bookmark_note, value=MessagesCZ.lottie_sticker, inline=False)
+
         embed.add_field(name="Channel", value=f"{inter.message.channel.mention} - #{inter.message.channel}")
         return ([embed], images, files_attached)

--- a/cogs/bookmark/messages_cz.py
+++ b/cogs/bookmark/messages_cz.py
@@ -4,5 +4,7 @@ from config.messages import Messages as GlobalMessages
 class MessagesCZ(GlobalMessages):
     bookmark_title = "Záložka na serveru `{server}`"
     bookmark_created = "Záložka `{title_name}` vytvořena"
+    bookmark_note = "Poznámka"
     upload_limit = "Zpráva obsahuje přílohu přesahující upload limit, doporučuji si tuto přílohu stáhnout. V připadě smazání původní zprávy nebude příloha dostupná."
     original_message = "Původní zpráva"
+    lottie_sticker = "Pokusil/a jsi se uložit výchozí Discord sticker. Tato API funkce nefunguje dobře a proto raději neposílám nic. Ulož si ji prosím jiným způsobem, pokud ji potřebuješ. <:KKomrade:484470873001164817>"


### PR DESCRIPTION
## PR type
- [x] Bug Fix

## Description
Lottie sticker can't be converted into a file so instead it's ignored and a note is added to the embed.

## Related Issue(s)
- Resolves #777

## After checks
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [x] Reload cog(s) [bookmark]
