### PR TITLE
Report delete button traceback

### DIFF
--- a/cogs/report/features.py
+++ b/cogs/report/features.py
@@ -40,13 +40,13 @@ async def set_tag(forum: disnake.ForumChannel, forum_thread: disnake.Thread, tag
 
 
 async def embed_resolved(
-    buttons: list[disnake.ui.Button], author: str, embed: dict, report_type: str, resolved: bool
+    buttons: list[disnake.ui.Button], author: str, embed_dict: dict, report_type: str, resolved: bool
 ) -> disnake.Embed:
     """Changes the embed to a resolved embed or back to a report embed"""
     if resolved:
-        embed["color"] = disnake.Color.green()
-        embed["title"] = "Resolved"
-        for field in embed["fields"]:
+        embed_dict["color"] = disnake.Color.green()
+        embed_dict["title"] = "Resolved"
+        for field in embed_dict["fields"]:
             if field["name"] == "Resolved by":
                 field["value"] = author
         for button in buttons:
@@ -57,9 +57,9 @@ async def embed_resolved(
                 button.emoji = "✅"
                 button.disabled = False
     else:
-        embed["color"] = disnake.Color.red()
-        embed["title"] = f"{report_type.capitalize()} report"
-        for field in embed["fields"]:
+        embed_dict["color"] = disnake.Color.red()
+        embed_dict["title"] = f"{report_type.capitalize()} report"
+        for field in embed_dict["fields"]:
             if field["name"] == "Resolved by":
                 field["value"] = "---"
         for button in buttons:
@@ -68,7 +68,7 @@ async def embed_resolved(
                 button.label = "Resolve"
                 button.style = disnake.ButtonStyle.grey
                 button.emoji = "❌"
-    embed = disnake.Embed.from_dict(embed)
+    embed = disnake.Embed.from_dict(embed_dict)
     return embed
 
 

--- a/cogs/report/views.py
+++ b/cogs/report/views.py
@@ -186,17 +186,18 @@ class ReportMessageView(ReportView):
         report_message = await report_features.convert_url(inter, report.report_url)
         report_author = await self.get_report_author(report_id)
 
-        if message is None:
-            button.label = "Message not found"
-            description = MessagesCZ.message_already_deleted(
-                author=inter.author.mention, author_name=inter.author.name
-            )
-        else:
+        try:
+            await message.delete()
             button.label = f"Deleted by @{inter.author.name}"
             description = MessagesCZ.message_deleted(
                 author=inter.author.mention, author_name=inter.author.name
             )
-            await message.delete()
+        except (disnake.NotFound, AttributeError):
+            # message is None or already deleted, often it's cached message
+            button.label = "Message not found"
+            description = MessagesCZ.message_already_deleted(
+                author=inter.author.mention, author_name=inter.author.name
+            )
 
         title = MessagesCZ.message_deleted_title(id=report_id)
         embed = report_features.info_message_embed(inter, report, title, description)

--- a/cogs/report/views.py
+++ b/cogs/report/views.py
@@ -127,7 +127,7 @@ class ReportView(BaseView):
 
         await report_author.send(embed=embed_user)
         await inter.message.channel.send(embed=embed)
-        await inter.edit_original_response(content=None, embed=embed, view=self)
+        await inter.edit_original_response(embed=embed, view=self, attachments=None)
 
     @disnake.ui.button(
         label="Send answer", emoji="✉️", style=disnake.ButtonStyle.secondary, custom_id="report:answer"
@@ -154,7 +154,7 @@ class ReportView(BaseView):
 
         await report_author.send(embed=spam_embed)
         await report_message.channel.send(embed=spam_embed)
-        await inter.edit_original_response(embed=embed, view=self)
+        await inter.edit_original_response(embed=embed, view=self, attachments=None)
 
     async def on_error(self, error, item: disnake.ui.Item, interaction: disnake.MessageInteraction):
         if isinstance(error, ButtonInteractionError):
@@ -212,7 +212,7 @@ class ReportMessageView(ReportView):
 
         await report_message.channel.send(embed=embed)
         await report_author.send(embed=embed, view=ReportAnonymView(self.bot))
-        await inter.edit_original_response(view=self)
+        await inter.edit_original_response(view=self, attachments=None)
 
 
 class ReportAnonymView(BaseView):


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
Fix duplicating embedded image on report post (prob discord fault but is fixable with `attachments=None`)
Fix exception when removing the message in the deleted thread/channel (the message was cached).
Some nitpicks around types.

## Related Issue(s)
- Resolves #1084

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot