### PR TITLE
feat(verify): split verification for VUT and MUNI into separate commands

### DIFF
--- a/cogs/verify/cog.py
+++ b/cogs/verify/cog.py
@@ -41,14 +41,33 @@ class Verify(Base, commands.Cog):
     async def verify(
         self,
         inter: disnake.ApplicationCommandInteraction,
+    ):
+        await inter.response.defer(ephemeral=True)
+
+    @verify.sub_command(name="vut", description=MessagesCZ.verify_brief)
+    async def verify_vut(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
         login: str = commands.Param(description=MessagesCZ.verify_login_parameter),
     ):
         login = login.lower()
-        await inter.response.defer(ephemeral=True)
         if await self.dynamic_verify_manager.can_apply_rule(inter.user, login):
             await self.dynamic_verify_manager.request_access(login, inter)
             return
-        if await self.verification.send_code(login, inter):
+        if await self.verification.send_code(login, inter, muni=False):
+            await self.verification.clear_host_roles(inter)
+
+    @verify.sub_command(name="muni", description=MessagesCZ.verify_brief)
+    async def verify_muni(
+        self,
+        inter: disnake.ApplicationCommandInteraction,
+        login: str = commands.Param(description=MessagesCZ.verify_login_parameter_muni),
+    ):
+        login = login.lower()
+        if await self.dynamic_verify_manager.can_apply_rule(inter.user, login):
+            await self.dynamic_verify_manager.request_access(login, inter)
+            return
+        if await self.verification.send_code(login, inter, muni=True):
             await self.verification.clear_host_roles(inter)
 
     @verify.error

--- a/cogs/verify/messages_cz.py
+++ b/cogs/verify/messages_cz.py
@@ -3,7 +3,8 @@ from config.messages import Messages as GlobalMessages
 
 class MessagesCZ(GlobalMessages):
     verify_brief = "Ověření studenta pro přístup na server."
-    verify_login_parameter = "Přihlašovací FIT login (`xlogin00`), osobní 6 místné VUT číslo nebo MUNI UČO."
+    verify_login_parameter = "Přihlašovací FIT login (`xlogin00`), osobní 6 místné VUT číslo"
+    verify_login_parameter_muni = "UČO"
     verify_already_verified = "{user} Už jsi byl verifikován " \
                               "({admin} pls)."
     verify_send_dumbshit = "{user} Tvůj login. {emote}"


### PR DESCRIPTION
## PR type
- [x] New Feature

## Description
This should resolve the confusion for people who are not yet available in the API or have other reasons for not being recognized and it should also remove randomly sending emails to MUNI.

Dynamic verification is kinda of tricky, not sure where I should put it, so I kept it for both options to avoid confusion.

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

