### PR TITLE
fix(moderation): fix slowmode command calling defer twice

### DIFF
--- a/cogs/moderation/cog.py
+++ b/cogs/moderation/cog.py
@@ -40,7 +40,6 @@ class Moderation(Base, commands.Cog):
         ),
         channel: SLOWMODE_CHANNEL_TYPES = None,
     ):
-        await inter.response.defer(ephemeral=True)
         if channel is None:
             channel = inter.channel
         prev_delay = channel.slowmode_delay
@@ -51,7 +50,6 @@ class Moderation(Base, commands.Cog):
     @commands.check(permission_check.submod_plus)
     @_slowmode.sub_command(name="remove", description=MessagesCZ.remove_brief)
     async def remove(self, inter: disnake.GuildCommandInteraction, channel: SLOWMODE_CHANNEL_TYPES = None):
-        await inter.response.defer(ephemeral=True)
         if channel is None:
             channel = inter.channel
         prev_delay = inter.channel.slowmode_delay


### PR DESCRIPTION
## PR type
- [x] Bug Fix

## Description
This was added recently (https://github.com/vutfitdiscord/rubbergod/pull/1103) and it is causing issues, because defer is already called in the parent command.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

