### PR TITLE
feat,chore: Add deployment mutex

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,6 +23,28 @@ jobs:
           username: ${{ secrets.PRODUCTION_USERNAME }}
           port: 22
           script: |
+            echo "================== Lock Mutex =================="
+            LOCK="/tmp/deployment.lock"
+
+            remove_lock()
+            {
+                rm -f "$LOCK"
+            }
+
+            acquire_failed()
+            {
+                echo "Failed to acquire lock, perphaps a stale deployment is running requiring manual fix?"
+                exit 1
+            }
+
+            # !IMPORTANT: For this to work, the remote server has to have `procmail` installed.
+            # Try to lock 5 times with a 60s sleep time between retries
+            # Remove any lock older than 10min (600s) and then wait 30s
+            lockfile -60 -r 5 -l 600 -s 30 "$LOCK" || acquire_failed
+
+            # Remove lock on exit
+            trap remove_lock EXIT
+
             echo "================== Pull Changes =================="
             cd rubbergod
             git pull

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     needs: pre_commit_ci
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && !contains(github.event.pull_request.labels.*.name, 'no-deployment')
     steps:
       - name: Execute deployment on SSH
         uses: appleboy/ssh-action@v1.0.3

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e # Exit on error
+
 DEFAULT_UID=$(id -u)
 DEFAULT_GID=$(id -g)
 


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [ ] Refactor/Enhancement
- [ ] New Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->

Implement deployment mutex to prevent deadlock and other race conditions when multiple deployments are in progress. Uses `lockfile` cmd from `procmail` because it seems to be the most robust solution available. The command is already installed on production, so there is no need to do anything else.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

Resolves #1145

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->

- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
