### PR TITLE
feat: make is_bot_admin into command_check itself

### DIFF
--- a/cogs/dynamicconfig/cog.py
+++ b/cogs/dynamicconfig/cog.py
@@ -12,7 +12,7 @@ from disnake.ext import commands
 
 from cogs.base import Base
 from config.app_config import CONFIG_PATH, config_get_keys, load_config
-from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 
 from .messages_cz import MessagesCZ
@@ -27,7 +27,7 @@ class DynamicConfig(Base, commands.Cog):
         super().__init__()
         self.bot = bot
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="config")
     async def config_cmd(self, inter: disnake.ApplicationCommandInteraction):
         """

--- a/cogs/fitwide/cog.py
+++ b/cogs/fitwide/cog.py
@@ -16,7 +16,8 @@ from database.verification import PermitDB, ValidPersonDB, VerifyStatus
 from features.prompt import PromptSession
 from features.verification import Verification
 from features.verify_helper import VerifyHelper
-from permissions import permission_check, room_check
+from permissions import room_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 from utils import cooldowns
 from utils.general import edit_msg
@@ -49,7 +50,7 @@ class FitWide(Base, commands.Cog):
         user_logins = sorted(user_logins)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="verify_check", description=MessagesCZ.verify_check_brief)
     async def verify_check(self, inter: disnake.ApplicationCommandInteraction):
@@ -68,7 +69,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="status_check", description=MessagesCZ.status_check_brief)
     async def status_check(self, inter: disnake.ApplicationCommandInteraction):
@@ -99,7 +100,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="zapis_check", description=MessagesCZ.zapis_check_brief)
     async def zapis_check(self, inter: disnake.ApplicationCommandInteraction):
@@ -126,7 +127,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="mit_check", description=MessagesCZ.mit_check_brief)
     async def mit_check(self, inter: disnake.ApplicationCommandInteraction, p_debug: bool = True):
@@ -164,7 +165,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="dropout_check", description=MessagesCZ.dropout_check_brief)
     async def dropout_check(self, inter: disnake.ApplicationCommandInteraction, p_debug: bool = True):
@@ -205,7 +206,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.check(room_check.is_in_modroom)
     @commands.slash_command(name="role_check", description=MessagesCZ.role_check_brief)
     async def role_check(self, inter: disnake.ApplicationCommandInteraction):
@@ -233,7 +234,7 @@ class FitWide(Base, commands.Cog):
         await message.reply(MessagesCZ.role_check_end)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="increment_roles", description=MessagesCZ.increment_roles_brief)
     async def increment_roles(self, inter: disnake.ApplicationCommandInteraction):
         await inter.send(MessagesCZ.increment_roles_start)

--- a/cogs/ios/cog.py
+++ b/cogs/ios/cog.py
@@ -9,6 +9,7 @@ from disnake.ext import commands, tasks
 
 from cogs.base import Base
 from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 from utils import cooldowns
 
@@ -33,7 +34,7 @@ class IOS(Base, commands.Cog):
     async def _ios(self, inter: disnake.ApplicationCommandInteraction):
         pass
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @_ios.sub_command(name="start", description=MessagesCZ.task_start_brief)
     async def ios_task_start(self, inter: disnake.ApplicationCommandInteraction):
         try:
@@ -42,7 +43,7 @@ class IOS(Base, commands.Cog):
         except RuntimeError:
             await inter.send(MessagesCZ.task_start_already_set)
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @_ios.sub_command(name="stop", description=MessagesCZ.task_stop_brief)
     async def ios_task_stop(self, inter: disnake.ApplicationCommandInteraction):
         if self.ios_task.is_running():
@@ -51,7 +52,7 @@ class IOS(Base, commands.Cog):
         else:
             await inter.send(MessagesCZ.task_nothing_to_stop)
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @_ios.sub_command(name="cancel", description=MessagesCZ.task_cancel_brief)
     async def ios_task_cancel(self, inter: disnake.ApplicationCommandInteraction):
         if self.ios_task.is_running():

--- a/cogs/karma/cog.py
+++ b/cogs/karma/cog.py
@@ -14,7 +14,8 @@ from cogs.grillbotapi.cog import GrillbotApi
 from database.karma import KarmaDB
 from features.leaderboard import LeaderboardPageSource
 from features.reaction_context import ReactionContext
-from permissions import permission_check, room_check
+from permissions import room_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 from utils import cooldowns
 
@@ -227,7 +228,7 @@ class Karma(Base, commands.Cog):
         await inter.edit_original_response(embed=embed, view=view)
         view.message = await inter.original_message()
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="karma_mod", description=MessagesCZ.karma_brief)
     async def _karma_mod(self, inter: disnake.ApplicationCommandInteraction):
         pass

--- a/cogs/review/cog.py
+++ b/cogs/review/cog.py
@@ -12,7 +12,7 @@ import utils
 from buttons.embed import PaginationView
 from cogs.base import Base
 from database.review import ProgrammeDB, ReviewDB, SubjectDB, SubjectDetailsDB
-from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 from utils import cooldowns
 
@@ -116,7 +116,7 @@ class Review(Base, commands.Cog):
         """
         await inter.response.defer()
         if id is not None:
-            if permission_check.is_bot_admin(inter, False):
+            if PermissionsCheck.is_bot_admin(inter, False):
                 review = ReviewDB.get_review_by_id(id)
                 if review:
                     review.remove()
@@ -143,7 +143,7 @@ class Review(Base, commands.Cog):
 
     @cooldowns.short_cooldown
     @commands.slash_command(name="subject")
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     async def subject(self, inter: disnake.ApplicationCommandInteraction):
         """Group of commands for managing subjects in DB"""
         await inter.response.defer()

--- a/cogs/system/cog.py
+++ b/cogs/system/cog.py
@@ -15,7 +15,7 @@ from cogs.base import Base
 from database.error import ErrorLogDB
 from features.error import ErrorLogger
 from features.git import Git
-from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 from utils import cooldowns
 from utils.colors import RubbergodColors
@@ -43,7 +43,7 @@ class System(Base, commands.Cog):
         if not start_streak:
             ErrorLogDB.set()
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="get_logs", description=MessagesCZ.get_logs_brief)
     async def get_logs(
         self,
@@ -83,7 +83,7 @@ class System(Base, commands.Cog):
 
         await inter.send(files=files)
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="shutdown", description=MessagesCZ.shutdown_brief)
     async def shutdown(self, inter: disnake.ApplicationCommandInteraction):
         await inter.send("Shutting down...")
@@ -92,7 +92,7 @@ class System(Base, commands.Cog):
         await self.bot.vutapi_session.close()
         await self.bot.close()
 
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="cogs", description=MessagesCZ.cogs_brief, guild_ids=[Base.config.guild_id])
     async def cogs(self, inter: disnake.ApplicationCommandInteraction):
         """
@@ -165,7 +165,7 @@ class System(Base, commands.Cog):
         await inter.edit_original_response(embed=embed)
 
     @cooldowns.default_cooldown
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     @commands.slash_command(name="command_checks", description=MessagesCZ.command_checks_brief)
     async def command_checks(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()

--- a/cogs/system/views.py
+++ b/cogs/system/views.py
@@ -3,7 +3,7 @@ import logging
 import disnake
 
 from buttons.base import BaseView
-from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 
 from . import features
@@ -46,7 +46,7 @@ class View(BaseView):
             pass
 
     async def interaction_check(self, inter: disnake.Interaction) -> bool:
-        if permission_check.is_bot_admin(inter):
+        if PermissionsCheck.is_bot_admin(inter):
             return True
         return False
 
@@ -96,7 +96,7 @@ class Dropdown(disnake.ui.Select):
     async def callback(self, inter: disnake.MessageInteraction) -> None:
         """React to user selecting cog(s)."""
         await inter.response.defer()
-        if not permission_check.is_bot_admin(inter):
+        if not PermissionsCheck.is_bot_admin(inter):
             return
 
         unloadable = [cog for cog in self.unloadable_cogs if cog in self.values]

--- a/cogs/warden/cog.py
+++ b/cogs/warden/cog.py
@@ -13,7 +13,7 @@ from disnake.ext import commands
 import utils
 from cogs.base import Base
 from database.image import ImageDB
-from permissions import permission_check
+from permissions.permission_check import PermissionsCheck
 from rubbergod import Rubbergod
 
 from . import features
@@ -92,7 +92,7 @@ class Warden(Base, commands.Cog):
                     pass
 
     @commands.group()
-    @commands.check(permission_check.is_bot_admin)
+    @PermissionsCheck.is_bot_admin()
     async def scan(self, ctx: commands.Context):
         """Scan for reposts"""
         if ctx.invoked_subcommand is None:


### PR DESCRIPTION
## PR type
- [x] Refactor/Enhancement

## Description
Instead of passing our check to command.check we can supply it ourselves. This will be useful for other commands where we can precisely tell the error instead of generic command.check fail error. 

## Related Issue(s)
- Related Issue #1126

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot