### PR TITLE
Autocreate error log table

### DIFF
--- a/cogs/system/cog.py
+++ b/cogs/system/cog.py
@@ -35,13 +35,6 @@ class System(Base, commands.Cog):
         self.git = Git()
 
         self.unloadable_cogs = ["system"]
-        self.check_first_boot()
-
-    def check_first_boot(self):
-        """Check if the bot is booting for the first time. If so, set the error log."""
-        start_streak, end_streak = ErrorLogDB.get_longest_streak()
-        if not start_streak:
-            ErrorLogDB.set()
 
     @commands.check(permission_check.is_bot_admin)
     @commands.slash_command(name="get_logs", description=MessagesCZ.get_logs_brief)
@@ -144,9 +137,8 @@ class System(Base, commands.Cog):
     @commands.slash_command(name="uptime", description=MessagesCZ.uptime_brief)
     async def uptime(self, inter: disnake.ApplicationCommandInteraction):
         await inter.response.defer()
-        now = datetime.now().replace(microsecond=0)
-        delta = now - boottime
-        count = self.error_log.log_error_time(set=False)
+        delta = datetime.now().replace(microsecond=0) - boottime
+        count = ErrorLogDB.days_without_error()
         embed = disnake.Embed(
             title="Uptime",
             description=f"{count} days without an accident.",

--- a/database/db_migrations.py
+++ b/database/db_migrations.py
@@ -29,5 +29,8 @@ def init_db(commit: bool = True):
     database.base.metadata.create_all(database.db)
     rubbergod_logger.info("Tables created")
 
+    # Initialize default values
+    ErrorLogDB.init()
+
     if commit:
         session.commit()

--- a/database/error.py
+++ b/database/error.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from datetime import date
 from enum import IntEnum
-from typing import Optional
 
 from sqlalchemy import Column, Date, Integer
 
@@ -18,35 +17,50 @@ class ErrorRow(IntEnum):
 
 
 class ErrorLogDB(database.base):  # type: ignore
+    """Database model for error log.
+
+    Always has 3 rows:
+    - `last_error` - date of the last error
+    - `start_streak` - start date of the longest streak
+    - `end_streak` - end date of the longest streak
+    """
+
     __tablename__ = "bot_error_log"
 
     id = Column(Integer, primary_key=True)
     date = Column(Date, default=date.today())
 
     @classmethod
-    def init(cls) -> tuple[ErrorLogDB, ErrorLogDB, ErrorLogDB]:
-        """initialize database with default values"""
+    def init(cls) -> None:
+        """Initialize database with default rows."""
+        if session.query(cls).count():
+            # If the table is not empty do not initialize
+            return
+
         last_error = cls(id=ErrorRow.last_error)
         start_streak = cls(id=ErrorRow.start_streak)
         end_streak = cls(id=ErrorRow.end_streak)
         for error in [last_error, start_streak, end_streak]:
-            session.merge(error)
+            session.add(error)
+
         session.commit()
-        return last_error, start_streak, end_streak
+        return
 
     @classmethod
-    def set(cls) -> bool:
-        """Set new date of last error.
-        :return: Whether the date got updated or not.
-        """
+    def get(cls, id: ErrorRow) -> ErrorLogDB:
+        return session.query(cls).get(id)
+
+    @classmethod
+    def set(cls) -> None:
+        """Set new date of last error."""
         last_error, start_streak, end_streak = cls.get_all()
         today = date.today()
 
         if getattr(last_error, "date", None) == today:
-            return False
+            return
 
-        current_streak = today - last_error.date  # type: ignore
-        longest_streak = end_streak.date - start_streak.date  # type: ignore
+        current_streak = today - last_error.date
+        longest_streak = end_streak.date - start_streak.date
 
         if current_streak > longest_streak:
             start_streak.date = last_error.date
@@ -54,31 +68,29 @@ class ErrorLogDB(database.base):  # type: ignore
 
         last_error.date = today
         session.commit()
-        return True
+        return
 
     @classmethod
-    def get(cls, id) -> Optional[ErrorLogDB]:
-        return session.query(cls).get(id)
+    def days_without_error(cls) -> int:
+        last_error = cls.get(ErrorRow.last_error)
+        today = date.today()
+        return (today - last_error.date).days
 
     @classmethod
     def get_all(cls) -> tuple[ErrorLogDB, ErrorLogDB, ErrorLogDB]:
         last_error = cls.get(ErrorRow.last_error)
         start_streak = cls.get(ErrorRow.start_streak)
         end_streak = cls.get(ErrorRow.end_streak)
-        if any(error is None for error in [last_error, start_streak, end_streak]):
-            last_error, start_streak, end_streak = cls.init()
         return last_error, start_streak, end_streak  # type: ignore
 
     @classmethod
-    def get_longest_streak(cls) -> tuple[Date | None, Date]:
+    def get_longest_streak(cls) -> tuple[Date, Date]:
         last_error, start_streak, end_streak = cls.get_all()
         today = date.today()
 
-        if not last_error.date:
-            return None, today
-
         current_streak = today - last_error.date
         longest_streak = end_streak.date - start_streak.date
+
         if current_streak > longest_streak:
             start_streak.date = last_error.date
             end_streak.date = today

--- a/features/error.py
+++ b/features/error.py
@@ -18,7 +18,7 @@ from cogs.gif.features import ImageHandler
 from config.app_config import config
 from config.messages import Messages
 from database import session
-from database.error import ErrorLogDB, ErrorRow
+from database.error import ErrorLogDB
 from database.stats import ErrorEvent
 from permissions import custom_errors, permission_check
 from rubbergod import Rubbergod
@@ -110,21 +110,6 @@ class ErrorLogger:
             output = "".join(traceback.format_exception(type(error), error, error.__traceback__))
             rubbegod_logger.warning(output)
 
-    def log_error_time(self, set=True) -> int:
-        """Log details of last exception and return number of days since last exception"""
-        try:
-            today = datetime.date.today()
-            last_exception = ErrorLogDB.get(ErrorRow.last_error)
-            if last_exception:
-                count = (today - last_exception.date).days
-            else:
-                count = 0
-            if set:
-                ErrorLogDB.set()
-            return count
-        except Exception:
-            return 0
-
     def create_embed(
         self,
         command: str,
@@ -134,7 +119,8 @@ class ErrorLogger:
         jump_url: str | None,
         extra_fields: dict[str, str] = None,
     ):
-        count = self.log_error_time()
+        count = ErrorLogDB.days_without_error()
+        ErrorLogDB.set()
         embed = disnake.Embed(
             title=f"{count} days without an accident.\nIgnoring exception in {command}",
             color=0xFF0000,


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Refactor/Enhancement

## Description
Small changes around handling setting dates in error log table
The introduced problem was created by using merge method on empty table. This will auto create rows if they do not exist. Hence we don't need to check if they exist, because they always must be there.

## Related Issue(s)
none

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot