### PR TITLE
fix: correct deployment output parsing in workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -17,7 +17,7 @@ jobs:
         labels: '["no-deployment"]'
       timeout-minutes: 5
     outputs:
-      deploy: "${{ ! steps.check_deployment.outputs.result }}"
+      deploy: "${{ ! fromJson(steps.check_deployment.outputs.result) }}"
 
   pre_commit_ci:
     uses: vutfitdiscord/rubbergod/.github/workflows/lint.yml@main


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
Fix check deployment workflow. The variables in Github Actions are not types but string, fromJson makes them parses them to type which can be negated.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)