### PR TITLE
change repo link to current one in PR message

### DIFF
--- a/cogs/meme/messages_cz.py
+++ b/cogs/meme/messages_cz.py
@@ -5,4 +5,4 @@ class MessagesCZ(GlobalMessages):
     uhoh_counter = "{uhohs} uh ohs od spuštění."
     uhoh_brief = "Vypíše počet uh ohs od spuštění"
     uhoh = "uh oh"
-    pr_meme = "https://github.com/Toaster192/rubbergod/pulls"
+    pr_meme = "https://github.com/vutfitdiscord/rubbergod/pulls"


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [ ] Refactor/Enhancement
- [ ] New Feature
- [X] Bug Fix
- [ ] Documentation Update

## Description
Just changing the link that gets sent when someone messages `PR` to the current one (https://github.com/vutfitdiscord/rubbergod/pulls), instead of old Toaster192 repo.

## Related Issue(s)
None
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
