### PR TITLE
Downloading emojis raising error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__
 .mypy_cache
 
 # Local files
-emojis.zip
+guilds/
 timeout_wars
 merlin-latest
 service_logs.txt

--- a/cogs/emoji/cog.py
+++ b/cogs/emoji/cog.py
@@ -50,6 +50,7 @@ class Emoji(Base, commands.Cog):
         await inter.response.defer(ephemeral=PermissionsCheck.is_botroom(inter))
 
     @cooldowns.default_cooldown
+    @commands.guild_only()
     @emoji.sub_command(name="all", description=MessagesCZ.emoji_all_brief)
     async def get_emojis(self, inter: disnake.ApplicationCommandInteraction):
         """Get all emojis from server"""

--- a/init.sh
+++ b/init.sh
@@ -7,6 +7,6 @@ DEFAULT_GID=$(id -g)
 
 # Create logs folder with permissions
 echo "Updating logs folder permissions"
-mkdir -p logs
-sudo chmod -R 777 logs
-sudo chown -R $DEFAULT_UID:$DEFAULT_GID logs/
+mkdir -p logs guilds
+sudo chmod -R 777 logs guilds
+sudo chown -R $DEFAULT_UID:$DEFAULT_GID logs/ guilds/

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,1 +1,1 @@
-MAX_ATTACHMENT_SIZE = 25_000_000  # 25MB is maximum size of attachment in bytes bot can send without nitro, for guilds you can use `guild.filesize_limit`
+MAX_ATTACHMENT_SIZE = 10_000_000  # 10MB is maximum size of attachment in bytes bot can send without nitro, for guilds you can use `guild.filesize_limit`


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
`/emoji all` raises an error because of the maximum file size. Emojis are now only downloadable in guilds, and support for multiple servers is in place.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [x] PR was tested

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Change config
- [x] Restart bot