### PR TITLE
fix(streamlinks): escape member name

### DIFF
--- a/cogs/streamlinks/cog.py
+++ b/cogs/streamlinks/cog.py
@@ -31,6 +31,8 @@ pagination_regex = re.compile(r"^\[([^\]]*)\]\s*Page:\s*(\d*)\s*\/\s*(\d*)")
 subjects: list[tuple[str]] = []
 subjects_with_stream: list[tuple[str]] = []
 
+escape = disnake.utils.escape_markdown
+
 
 async def autocomp_subjects(inter: disnake.ApplicationCommandInteraction, user_input: str):
     return [subject[0] for subject in subjects if user_input.lower() in subject[0]][:25]
@@ -95,7 +97,9 @@ class StreamLinks(Base, commands.Cog):
         messages = [f"Streamy k **{subject.upper()}**:"]
         for stream in streamlinks:
             date = stream.created_at.strftime("%d. %m. %Y")
-            messages.append(f"**{stream.member_name}** ({date}) - [{stream.description}](<{stream.link}>)\n")
+            messages.append(
+                f"**{escape(stream.member_name)}** ({date}) - [{stream.description}](<{stream.link}>)\n"
+            )
 
         await send_list_of_messages(inter, messages, ephemeral=PermissionsCheck.is_botroom(inter))
 
@@ -246,7 +250,7 @@ class StreamLinks(Base, commands.Cog):
         embed = disnake.Embed(title="Odkaz na stream byl smazán", color=disnake.Color.yellow())
         embed.add_field(name="Provedl", value=user.name)
         embed.add_field(name="Předmět", value=stream.subject.upper())
-        embed.add_field(name="Od", value=stream.member_name)
+        embed.add_field(name="Od", value=escape(stream.member_name))
         embed.add_field(name="Popis", value=stream.description[:1024])
         embed.add_field(name="Odkaz", value=f"[link]({stream.link})", inline=False)
         embed.timestamp = datetime.now(timezone.utc)
@@ -314,7 +318,7 @@ class StreamLinks(Base, commands.Cog):
             embed.set_image(url=streamlink.thumbnail_url)
 
         embed.add_field(name="Předmět", value=streamlink.subject.upper(), inline=True)
-        embed.add_field(name="Od", value=streamlink.member_name, inline=True)
+        embed.add_field(name="Od", value=escape(streamlink.member_name), inline=True)
         embed.add_field(
             name="Datum vydání",
             value=disnake.utils.format_dt(streamlink.created_at, style="d"),


### PR DESCRIPTION
## PR type
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->
`/streamlinks list` & `/streamlinks get` do not escape member names properly, so characters like _ can be treated as markdown syntax which breaks the listing. This PR adds character escaping to the appropriate listings.

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->
Fixes #1143

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [x] Reload cog(s) [streamlinks]

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
