### PR TITLE
fix deprecation dm_permission

### DIFF
--- a/cogs/verify/cog.py
+++ b/cogs/verify/cog.py
@@ -37,7 +37,11 @@ class Verify(Base, commands.Cog):
 
     @cooldowns.default_cooldown
     @commands.check(is_valid_guild)
-    @commands.slash_command(name="verify", description=MessagesCZ.verify_brief, dm_permission=True)
+    @commands.slash_command(
+        name="verify",
+        description=MessagesCZ.verify_brief,
+        contexts=disnake.InteractionContextTypes(bot_dm=True),
+    )
     async def verify(
         self,
         inter: disnake.ApplicationCommandInteraction,


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
Disnake changed dm_permission to contexts parameter.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot