### PR TITLE
Add Prometheus logging

### DIFF
--- a/cogs/README.md
+++ b/cogs/README.md
@@ -304,6 +304,16 @@ Cog for sending name days and birthdays.\
     - send_names
 ---
 
+### [Prometheus](prometheus/cog.py)
+
+Module for tracking statistics about bot into [Grafana dashboard](prometheus/grafana_dashboard.json). You will need Grafana server and Prometheus server running alongside bot.\
+**Commands:**
+
+**Tasks:**
+
+    - latency_loop
+---
+
 ### [Random](random/cog.py)
 
 Implementing commands using random module.\

--- a/cogs/prometheus/LICENSE
+++ b/cogs/prometheus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Apollo-Roboto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cogs/prometheus/README.md
+++ b/cogs/prometheus/README.md
@@ -1,0 +1,22 @@
+# Prometheus cog
+
+## Source module
+
+Original work: <https://github.com/Apollo-Roboto/discord.py-ext-prometheus>
+
+The `cog.py` module is an adaptation of the repository mentioned above. It has been modified to work with the disnake library and includes custom changes that are more suitable for our requirements.
+
+Rubbergod and Prometheus must be on the same network to reach each other. Add the following to your Prometheus server config.
+
+```yaml
+- job_name: rubbergod-bot
+static_configs:
+    - targets:
+    - rubbergod-bot:8000
+```
+
+## Setup for Grafana
+
+Import the dashboard from `grafana_dashboard.json` to your Grafana server.
+
+Update the `datasource` variable in dashboard to your prometheus server.

--- a/cogs/prometheus/__init__.py
+++ b/cogs/prometheus/__init__.py
@@ -1,0 +1,7 @@
+from rubbergod import Rubbergod
+
+from .cog import Prometheus
+
+
+def setup(bot: Rubbergod):
+    bot.add_cog(Prometheus(bot))

--- a/cogs/prometheus/cog.py
+++ b/cogs/prometheus/cog.py
@@ -1,0 +1,186 @@
+import logging
+from threading import Thread
+from wsgiref.simple_server import WSGIServer
+
+import disnake
+from disnake import AutoShardedClient, Interaction, InteractionType
+from disnake.ext import commands, tasks
+from prometheus_client import REGISTRY, start_http_server
+
+from cogs.base import Base
+from rubbergod import Rubbergod
+
+from .features import (
+    CHANNEL_GAUGE,
+    COMMANDS_GAUGE,
+    CONNECTION_GAUGE,
+    GUILD_GAUGE,
+    LATENCY_GAUGE,
+    METRICS,
+    ON_COMMAND_COUNTER,
+    ON_INTERACTION_COUNTER,
+    USER_GAUGE,
+)
+
+log = logging.getLogger("prometheus")
+
+
+class Prometheus(Base, commands.Cog):
+    """
+    A Cog to be added to a discord bot. The prometheus server will start once the bot is ready
+    using the `on_ready` listener.
+    """
+
+    def __init__(self, bot: Rubbergod, port: int = 8000):
+        super().__init__()
+        self.bot: Rubbergod = bot
+        self.port: int = port
+        self.prometheus_running: bool = False
+        self.prometheus_server: WSGIServer
+        self.prometheus_thread: Thread
+        self.tasks = [self.latency_loop.start()]
+
+    def init_gauges(self):
+        log.info("Initializing gauges")
+
+        num_of_guilds = len(self.bot.guilds)
+        GUILD_GAUGE.set(num_of_guilds)
+
+        num_of_channels = len(set(self.bot.get_all_channels()))
+        CHANNEL_GAUGE.set(num_of_channels)
+
+        num_of_users = len(set(self.bot.get_all_members()))
+        USER_GAUGE.set(num_of_users)
+
+        num_of_commands = self.get_all_commands()
+        COMMANDS_GAUGE.set(num_of_commands)
+
+    def get_all_commands(self) -> int:
+        basic_commands = len(self.bot.commands)
+        application_commands = len(self.bot.application_commands)
+        return basic_commands + application_commands
+
+    def start_prometheus(self):
+        log.info(f"Starting Prometheus Server on port {self.port}")
+        self.prometheus_server, self.prometheus_thread = start_http_server(self.port)
+
+    def stop_prometheus(self):
+        log.info("Stopping Prometheus Server")
+        for collector in METRICS:
+            REGISTRY.unregister(collector)
+
+        self.prometheus_server.shutdown()
+        self.prometheus_server.server_close()
+        self.prometheus_thread.join()
+
+        self.prometheus_running = False
+
+    @tasks.loop(seconds=5)
+    async def latency_loop(self):
+        COMMANDS_GAUGE.set(self.get_all_commands())
+        if isinstance(self.bot, AutoShardedClient):
+            for shard, latency in self.bot.latencies:
+                LATENCY_GAUGE.labels(shard).set(latency)
+        else:
+            LATENCY_GAUGE.labels(None).set(self.bot.latency)
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        # some gauges needs to be initialized after each reconnect
+        # (value could changed during an outtage)
+        self.init_gauges()
+
+        # Set connection back up (since we in on_ready)
+        CONNECTION_GAUGE.labels(None).set(1)
+
+        # on_ready can be called multiple times, this started
+        # check is to make sure the service does not start twice
+        if not self.prometheus_running:
+            self.start_prometheus()
+
+    @commands.Cog.listener()
+    async def on_command(self, ctx: commands.Context):
+        shard_id = ctx.guild.shard_id if ctx.guild else None
+        ON_COMMAND_COUNTER.labels(shard_id, ctx.guild.id, ctx.command.name).inc()
+
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: Interaction):
+        shard_id = interaction.guild.shard_id if interaction.guild else None
+
+        # command name can be None if coming from a view (like a button click) or a modal
+        command_name = None
+        if interaction.type == InteractionType.application_command:
+            if isinstance(interaction, disnake.ApplicationCommandInteraction):
+                # Application Command
+                command_name = interaction.application_command.qualified_name
+            else:
+                # Context Command
+                command_name = interaction.command
+
+        ON_INTERACTION_COUNTER.labels(
+            shard_id, interaction.type.name, interaction.guild.id, command_name
+        ).inc()
+
+    @commands.Cog.listener()
+    async def on_connect(self):
+        CONNECTION_GAUGE.labels(None).set(1)
+
+    @commands.Cog.listener()
+    async def on_resumed(self):
+        CONNECTION_GAUGE.labels(None).set(1)
+
+    @commands.Cog.listener()
+    async def on_disconnect(self):
+        CONNECTION_GAUGE.labels(None).set(0)
+
+    @commands.Cog.listener()
+    async def on_shard_ready(self, shard_id):
+        CONNECTION_GAUGE.labels(shard_id).set(1)
+
+    @commands.Cog.listener()
+    async def on_shard_connect(self, shard_id):
+        CONNECTION_GAUGE.labels(shard_id).set(1)
+
+    @commands.Cog.listener()
+    async def on_shard_resumed(self, shard_id):
+        CONNECTION_GAUGE.labels(shard_id).set(1)
+
+    @commands.Cog.listener()
+    async def on_shard_disconnect(self, shard_id):
+        CONNECTION_GAUGE.labels(shard_id).set(0)
+
+    @commands.Cog.listener()
+    async def on_guild_join(self, _):
+        # The number of guilds, channels and users needs to be updated all together
+        self.init_gauges()
+
+    @commands.Cog.listener()
+    async def on_guild_remove(self, _):
+        # The number of guilds, channels and users needs to be updated all together
+        self.init_gauges()
+
+    @commands.Cog.listener()
+    async def on_guild_channel_create(self, _):
+        CHANNEL_GAUGE.inc()
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(self, _):
+        CHANNEL_GAUGE.dec()
+
+    @commands.Cog.listener()
+    async def on_member_join(self, _):
+        USER_GAUGE.inc()
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, _):
+        USER_GAUGE.dec()
+
+    async def cog_load(self):
+        await super().cog_load()
+        if self.bot.is_initialized:
+            # reloading the cog won't trigger on_ready so we need to call it manually to start the server
+            await self.on_ready()
+
+    def cog_unload(self) -> None:
+        super().cog_unload()
+        self.stop_prometheus()

--- a/cogs/prometheus/features.py
+++ b/cogs/prometheus/features.py
@@ -1,0 +1,50 @@
+from prometheus_client import Counter, Gauge
+
+METRIC_PREFIX = "discord_"
+
+COMMANDS_GAUGE = Gauge(METRIC_PREFIX + "stat_total_commands", "Number of commands")
+
+USER_GAUGE = Gauge(METRIC_PREFIX + "stat_total_users", "Number of users this bot can see")
+
+CONNECTION_GAUGE = Gauge(
+    METRIC_PREFIX + "connected",
+    "Determines if the bot is connected to Discord",
+    ["shard"],
+)
+
+LATENCY_GAUGE = Gauge(
+    METRIC_PREFIX + "latency",
+    "latency to Discord",
+    ["shard"],
+    unit="seconds",
+)
+
+ON_INTERACTION_COUNTER = Counter(
+    METRIC_PREFIX + "event_on_interaction",
+    "Number of interactions called by users",
+    ["shard", "interaction", "guild", "command"],
+)
+
+ON_COMMAND_COUNTER = Counter(
+    METRIC_PREFIX + "event_on_command",
+    "Number of commands called by users",
+    ["shard", "guild", "command"],
+)
+
+GUILD_GAUGE = Gauge(METRIC_PREFIX + "stat_total_guilds", "Number of guilds this bot is a member of")
+
+CHANNEL_GAUGE = Gauge(
+    METRIC_PREFIX + "stat_total_channels",
+    "Number of channels this bot is has access to",
+)
+
+METRICS = [
+    COMMANDS_GAUGE,
+    USER_GAUGE,
+    CONNECTION_GAUGE,
+    LATENCY_GAUGE,
+    ON_INTERACTION_COUNTER,
+    ON_COMMAND_COUNTER,
+    GUILD_GAUGE,
+    CHANNEL_GAUGE,
+]

--- a/cogs/prometheus/grafana_dashboard.json
+++ b/cogs/prometheus/grafana_dashboard.json
@@ -1,0 +1,1530 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+          },
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "This is a dashboard for the discord-ext-prometheus Python library.",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 1,
+    "id": 8,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "description": "Since last reboot",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "decimals": 0,
+            "fieldMinMax": false,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "blue"
+                },
+                {
+                  "color": "green",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 10,
+          "w": 8,
+          "x": 0,
+          "y": 0
+        },
+        "id": 57,
+        "options": {
+          "displayMode": "basic",
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "maxVizHeight": 300,
+          "minVizHeight": 10,
+          "minVizWidth": 0,
+          "namePlacement": "auto",
+          "orientation": "horizontal",
+          "reduceOptions": {
+            "calcs": [
+              "lastNotNull"
+            ],
+            "fields": "",
+            "values": false
+          },
+          "showUnfilled": true,
+          "sizing": "auto",
+          "text": {},
+          "valueMode": "color"
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "discord_event_on_interaction_total{job=~\"$job\", command!=\"None\"}",
+            "fullMetaSearch": false,
+            "hide": false,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{command}}",
+            "range": true,
+            "refId": "A",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "exemplar": false,
+            "expr": "discord_event_on_command_total{job=~\"$job\"}",
+            "format": "time_series",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "instant": false,
+            "legendFormat": "{{command}}",
+            "range": true,
+            "refId": "B",
+            "useBackend": false
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "disableTextWrap": false,
+            "editorMode": "builder",
+            "expr": "discord_event_on_interaction_total{job=~\"$job\", command=\"None\"}",
+            "fullMetaSearch": false,
+            "hide": true,
+            "includeNullMetadata": true,
+            "legendFormat": "{{interaction}}",
+            "range": true,
+            "refId": "C",
+            "useBackend": false
+          }
+        ],
+        "title": "Command Count",
+        "transformations": [
+          {
+            "id": "reduce",
+            "options": {
+              "labelsToFields": false,
+              "reducers": [
+                "lastNotNull"
+              ]
+            }
+          },
+          {
+            "id": "sortBy",
+            "options": {
+              "fields": {},
+              "sort": [
+                {
+                  "desc": true,
+                  "field": "Last *"
+                }
+              ]
+            }
+          },
+          {
+            "id": "rowsToFields",
+            "options": {
+              "mappings": []
+            }
+          }
+        ],
+        "type": "bargauge"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds"
+            },
+            "custom": {
+              "align": "auto",
+              "cellOptions": {
+                "mode": "gradient",
+                "type": "color-background"
+              },
+              "filterable": false,
+              "inspect": false,
+              "minWidth": 50
+            },
+            "mappings": [],
+            "noValue": "0",
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "red"
+                },
+                {
+                  "color": "#5764f233",
+                  "value": 0
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Uptime"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "s"
+                },
+                {
+                  "id": "mappings",
+                  "value": [
+                    {
+                      "options": {
+                        "0": {
+                          "color": "red",
+                          "index": 0,
+                          "text": "Down"
+                        }
+                      },
+                      "type": "value"
+                    }
+                  ]
+                },
+                {
+                  "id": "noValue",
+                  "value": "Down"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "job"
+              },
+              "properties": [
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "#5764f233"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "id": "custom.width"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Channels"
+              },
+              "properties": [
+                {
+                  "id": "custom.width"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Users"
+              },
+              "properties": [
+                {
+                  "id": "custom.width"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Guilds"
+              },
+              "properties": [
+                {
+                  "id": "custom.width"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "Commands"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 93
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 8,
+          "y": 0
+        },
+        "id": 42,
+        "options": {
+          "cellHeight": "sm",
+          "footer": {
+            "countRows": false,
+            "enablePagination": false,
+            "fields": [
+              "Value #A (lastNotNull)",
+              "Value #B (lastNotNull)",
+              "Value #C (lastNotNull)",
+              "Value #D (lastNotNull)"
+            ],
+            "reducer": [
+              "sum"
+            ],
+            "show": true
+          },
+          "frameIndex": 0,
+          "showHeader": true,
+          "sortBy": []
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_stat_total_users{job=~\"$job\"}",
+            "format": "table",
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_stat_total_guilds{job=~\"$job\"}",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_stat_total_channels{job=~\"$job\"}",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "C"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_stat_total_commands{job=~\"$job\"}",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "D"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "time() - process_start_time_seconds{job=~\"$job\"}",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "legendFormat": "__auto",
+            "range": false,
+            "refId": "E"
+          }
+        ],
+        "title": "",
+        "transformations": [
+          {
+            "id": "joinByField",
+            "options": {
+              "byField": "job",
+              "mode": "outer"
+            }
+          },
+          {
+            "id": "groupBy",
+            "options": {
+              "fields": {
+                "Users": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value #A": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value #B": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value #C": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value #D": {
+                  "aggregations": [
+                    "lastNotNull"
+                  ],
+                  "operation": "aggregate"
+                },
+                "Value #E": {
+                  "aggregations": [
+                    "last"
+                  ],
+                  "operation": "aggregate"
+                },
+                "job": {
+                  "aggregations": [],
+                  "operation": "groupby"
+                }
+              }
+            }
+          },
+          {
+            "id": "organize",
+            "options": {
+              "excludeByName": {
+                "job": false
+              },
+              "includeByName": {},
+              "indexByName": {},
+              "renameByName": {
+                "Value": "Users",
+                "Value #A (lastNotNull)": "Users",
+                "Value #B (lastNotNull)": "Guilds",
+                "Value #C (lastNotNull)": "Channels",
+                "Value #D (lastNotNull)": "Commands",
+                "Value #E (last)": "Uptime",
+                "Value (lastNotNull)": "Users",
+                "job": ""
+              }
+            }
+          }
+        ],
+        "type": "table"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "thresholds",
+              "seriesBy": "last"
+            },
+            "custom": {
+              "fillOpacity": 80,
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineWidth": 0,
+              "spanNulls": true
+            },
+            "decimals": 0,
+            "mappings": [
+              {
+                "options": {
+                  "0": {
+                    "color": "dark-red",
+                    "index": 0,
+                    "text": "Down"
+                  },
+                  "1": {
+                    "color": "#5764f233",
+                    "index": 1,
+                    "text": "Up"
+                  }
+                },
+                "type": "value"
+              }
+            ],
+            "max": 1,
+            "min": 0,
+            "noValue": "0",
+            "thresholds": {
+              "mode": "percentage",
+              "steps": [
+                {
+                  "color": "#5764f233"
+                }
+              ]
+            },
+            "unit": "bool_on_off"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 16,
+          "y": 0
+        },
+        "id": 43,
+        "options": {
+          "alignValue": "center",
+          "legend": {
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "mergeValues": false,
+          "rowHeight": 0.96,
+          "showValue": "auto",
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_connected{job=~\"$job\", shard=\"None\"}",
+            "format": "time_series",
+            "hide": false,
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "exemplar": false,
+            "expr": "discord_connected{job=~\"$job\",shard=~'[0-9]+'}",
+            "format": "time_series",
+            "instant": false,
+            "legendFormat": "{{job}} : {{shard}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Connection Over Time",
+        "type": "state-timeline"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 2,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 8,
+          "y": 5
+        },
+        "id": 47,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "discord_stat_total_guilds{job=~\"$job\"}",
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Guilds Over Time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic",
+              "seriesBy": "last"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 1,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 16,
+          "y": 5
+        },
+        "id": 31,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "discord_latency_seconds{job=~\"$job\", shard=~\"[0-9]+\"}",
+            "legendFormat": "{{job}} : {{shard}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "discord_latency_seconds{job=~\"$job\", shard=\"None\"}",
+            "hide": false,
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "B"
+          }
+        ],
+        "title": "Discord Latency",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 0,
+          "y": 10
+        },
+        "id": 14,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "round(sum(rate(discord_event_on_command_total{job=~\"$job\"}[1m])) by (job, command) * 45)",
+            "legendFormat": "{{command}}",
+            "range": true,
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "round(sum(rate(discord_event_on_interaction_total{job=~\"$job\", command=~\"None\"}[1m])) by (job, interaction) * 45)",
+            "hide": false,
+            "legendFormat": "{{interaction}}",
+            "range": true,
+            "refId": "B"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "round(sum(rate(discord_event_on_interaction_total{job=~\"$job\", command!=\"None\"}[1m])) by (job, command) * 45)",
+            "hide": false,
+            "legendFormat": "{{command}}",
+            "range": true,
+            "refId": "C"
+          }
+        ],
+        "title": "Command Activity",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 2,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 8,
+          "y": 10
+        },
+        "id": 48,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "discord_stat_total_channels{job=~\"$job\"}",
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Channels Over Time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "none"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 16,
+          "y": 10
+        },
+        "id": 22,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "rate(process_cpu_seconds_total{job=~\"$job\"}[1m])",
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "CPU Activity",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            }
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "ERROR"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "red",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "WARNING"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "orange",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "INFO"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "green",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 0,
+          "y": 15
+        },
+        "id": 28,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "round(max(rate(logging_total{job=~\"$job\"}[1m])) by (level) * 45)",
+            "interval": "",
+            "legendFormat": "__auto",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Logs",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 2,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 0,
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 8,
+          "y": 15
+        },
+        "id": 46,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "discord_stat_total_users{job=~\"$job\"}",
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Users Over Time",
+        "type": "timeseries"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${prometheus}"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic",
+              "seriesBy": "last"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "hue",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "decimals": 1,
+            "mappings": [],
+            "min": 0,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green"
+                }
+              ]
+            },
+            "unit": "s"
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 5,
+          "w": 8,
+          "x": 16,
+          "y": 15
+        },
+        "id": 24,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": false
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "multi",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "11.5.2",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "${prometheus}"
+            },
+            "editorMode": "code",
+            "expr": "scrape_duration_seconds{job=~\"$job\"}",
+            "legendFormat": "{{job}}",
+            "range": true,
+            "refId": "A"
+          }
+        ],
+        "title": "Scrape Duration",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "refresh": "5s",
+    "schemaVersion": 40,
+    "tags": [
+      "Discord"
+    ],
+    "templating": {
+      "list": [
+        {
+          "current": {
+            "text": "rubbergod-bot",
+            "value": "rubbergod-bot"
+          },
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${prometheus}"
+          },
+          "definition": "label_values(discord_connected,job)",
+          "description": "The Prometheus job",
+          "includeAll": true,
+          "label": "Job",
+          "name": "job",
+          "options": [],
+          "query": {
+            "qryType": 1,
+            "query": "label_values(discord_connected,job)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+          },
+          "refresh": 1,
+          "regex": "",
+          "sort": 5,
+          "type": "query"
+        },
+        {
+          "current": {
+            "text": "prometheus",
+            "value": "dedxnttp7cbggb"
+          },
+          "description": "Data source for the dashboard",
+          "label": "Prometheus",
+          "name": "prometheus",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "Discord Botasdfa",
+    "uid": "TGkTuzD4zasdfa",
+    "version": 4,
+    "weekStart": ""
+  }

--- a/config/config.template.toml
+++ b/config/config.template.toml
@@ -36,7 +36,7 @@ extensions = [
     'karma', 'meme', 'bettermeme', 'random', 'verify', 'fitwide', 'autopin',
     'help', 'review', 'week', 'roles', 'error', 'absolvent', 'gif', 'reactions',
     'streamlinks', 'bookmark', 'latex', 'info', 'fun', 'moderation', 'message',
-    'timeout', 'forum', 'report', 'contestvote', 'emoji', 'hugs',
+    'timeout', 'forum', 'report', 'contestvote', 'emoji', 'hugs', 'prometheus',
 ]
 
 [config]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
             - ./logs:/var/log:Z
             - postgres_data:/var/lib/postgresql/data/
             - ./database/backup/backup.sql:/docker-entrypoint-initdb.d/backup.sql
+        networks:
+            - postgres
+
     bot:
         image: rubbergod-bot
         container_name: rubbergod-bot
@@ -34,7 +37,15 @@ services:
             - ssh_config:/root/.ssh
         depends_on:
             - db
+        networks:
+            - postgres
+            - prometheus
 
 volumes:
     postgres_data:
     ssh_config:
+
+networks:
+    postgres:
+    prometheus:
+        external: true

--- a/features/logger.py
+++ b/features/logger.py
@@ -33,19 +33,27 @@ def setup_logging():
     disnake_logger = logging.getLogger("disnake")
     disnake_logger.setLevel(logging.INFO)
 
+    prometheus_logger = logging.getLogger("prometheus")
+    prometheus_logger.setLevel(logging.INFO)
+
     rubbergod_logger = logging.getLogger("rubbergod")
     rubbergod_logger.setLevel(logging.INFO)
 
     # These handlers need to be in this exact order or the log file will contain escape sequences
     file_formatter = logging.Formatter(output_fmt, dt_fmt, style)
-    file_handler = logging.FileHandler(filename="logs/rubbergod.log", encoding="utf-8", mode="w")
+    rubbergod_handler = logging.FileHandler(filename="logs/rubbergod.log", encoding="utf-8", mode="w")
+    prometheus_handler = logging.FileHandler(filename="logs/prometheus.log", encoding="utf-8", mode="w")
 
-    file_handler.setFormatter(file_formatter)
-    disnake_logger.addHandler(file_handler)
-    rubbergod_logger.addHandler(file_handler)
+    rubbergod_handler.setFormatter(file_formatter)
+    prometheus_handler.setFormatter(file_formatter)
+
+    disnake_logger.addHandler(rubbergod_handler)
+    prometheus_logger.addHandler(prometheus_handler)
+    rubbergod_logger.addHandler(rubbergod_handler)
 
     cli_handler = logging.StreamHandler()
     cli_formatter = CustomFormatter(output_fmt, dt_fmt, style)
     cli_handler.setFormatter(cli_formatter)
     disnake_logger.addHandler(cli_handler)
+    prometheus_logger.addHandler(cli_handler)
     rubbergod_logger.addHandler(cli_handler)

--- a/init.sh
+++ b/init.sh
@@ -6,7 +6,13 @@ DEFAULT_UID=$(id -u)
 DEFAULT_GID=$(id -g)
 
 # Create logs folder with permissions
-echo "Updating logs folder permissions"
+echo "Updating folder permissions"
 mkdir -p logs guilds
 sudo chmod -R 777 logs guilds
 sudo chown -R $DEFAULT_UID:$DEFAULT_GID logs/ guilds/
+
+# Create network prometheus if not exists
+if ! docker network inspect prometheus &>/dev/null; then
+    echo "Creating network prometheus"
+    docker network create prometheus
+fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ lxml
 python-dateutil
 CairoSVG>=2.5.2
 prettytable
+prometheus_client


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] New Feature

## Description
Add a Grafana dashboard with stats about our bot. Mostly, this will be command count, latency, uptime, guilds, users, etc.
Dashboard and Prometheus config must be applied with this PR merged.

Missing details:
- Currently supports command use only after the last reboot. Even though we can't command use persistent to boot this will be good insight for us. Might be resolved later.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [x] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Restart bot

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
![image](https://github.com/user-attachments/assets/f2dc46f5-85a8-4d50-b217-23543f230994)
