### PR TITLE
fix(compose): remove `bind` option from `volume`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
                 - rubbergod-bot
         volumes:
             - .:/rubbergod:Z
-            - ssh_config:/root/.ssh:Z
+            - ssh_config:/root/.ssh
         depends_on:
             - db
 


### PR DESCRIPTION
as pointed out by the newer version of `docker compose`:
```
WARN[0000] mount of type `volume` should not define `bind` option
```

## PR type
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
