### PR TITLE
fix(timeout): force `isself=False` on timeout from mod

### DIFF
--- a/cogs/timeout/cog.py
+++ b/cogs/timeout/cog.py
@@ -89,6 +89,7 @@ class Timeout(Base, commands.Cog):
                     starttime=inter.created_at,
                     endtime=endtime.utc,
                     reason=reason,
+                    isself=False
                 )
                 await features.add_field_timeout(
                     embed=embed,


### PR DESCRIPTION
It can happen that a person has a selftimeout which a mod can then replaces with normal timeout, but the status flag is not correctly reset so the timeout is not correctly prolonged after 28 days as it should be.

## PR type
<!-- check all applicable -->
<!--
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update
-->

## Description
<!--
Try to describe it as precisely as possible. You can add bullet list to point to specific tasks in this PR.
-->

## Related Issue(s)
<!--
For pull requests that relate or close an issue, please include them below.
We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull request to issue 1234.
And when we merge the pull request, Github will automatically close the issue.

- Related Issue #
- Closes #
- Resolves #
-->

## After checks
<!-- check all applicable -->
- [ ] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
<!--
- [ ] Update database
- [ ] Update packages, libraries, etc.
- [ ] Change config
- [ ] Restart bot
- [ ] Reload cog(s) [name(s)]
-->

## UI changes
<!-- [Optional] If there are UI changes, please paste screenshot(s) -->
