### PR TITLE
fix None for missing url when NASA API breaks

### DIFF
--- a/cogs/info/features.py
+++ b/cogs/info/features.py
@@ -63,7 +63,7 @@ async def create_nasa_embed(author: disnake.User, response: dict) -> tuple[disna
         url=MessagesCZ.nasa_url,
         color=disnake.Color.blurple(),
     )
-    url = response["hdurl"] if response.get("hdurl", None) else response["url"]
+    url = response["hdurl"] if response.get("hdurl", None) else response.get("url", None)
     utils.embed.add_author_footer(embed, author)
     if response.get("media_type", None) != "video":
         embed.set_image(url=url)


### PR DESCRIPTION
## PR type
<!-- check all applicable -->
- [x] Bug Fix

## Description
Sometimes the API doesn't have URL even though it should have. This will at least send the text and not return error.

## Related Issue(s)
None

## After checks
<!-- check all applicable -->
- [x] PR was tested
- [ ] Major change (packages, libraries, etc.)

## Post deployment
<!-- [Optional] Are there any post deployment tasks we need to perform? -->
- [x] Reload cog(s) **info**