### PR TITLE
Verify: Remove message on duplicate finish_verify calls

### DIFF
--- a/features/verification.py
+++ b/features/verification.py
@@ -227,9 +227,9 @@ class Verification(BaseFeature):
 
     async def finish_verify(self, inter: disnake.ModalInteraction, code: str, login: str) -> None:
         if await self.helper.has_role(inter.user, config.verification_role):
-            await inter.response.send_message(
-                MessagesCZ.verify_already_verified(user=inter.user.id, admin=config.admin_ids[0])
-            )
+            # This seems to also happen because the method is called multiple times
+            # (we assume due to people clicking twice on the submit button because of the delay).
+            # If that ever gets fixed we should perhaps send a verify_already_verified here
             return
 
         new_user = ValidPersonDB.get_user_by_login(login)


### PR DESCRIPTION
## PR type
- [ ] Refactor/Enhancement
- [ ] New Feature
- [x] Bug Fix
- [ ] Documentation Update


## Description
I got tired of getting tagged

## Related Issue(s)
Related Issue https://github.com/vutfitdiscord/rubbergod/issues/1140


## After checks
- [ ] PR was tested (xdddd)
- [ ] Major change (packages, libraries, etc.)

## Post deployment
- [ ] Reload cog `verify` 
