### PR TITLE
fix: detect NASA APOD API errors by HTTP status

### DIFF
--- a/cogs/info/features.py
+++ b/cogs/info/features.py
@@ -48,8 +48,8 @@ async def nasa_daily_image(rubbergod_session: aiohttp.ClientSession) -> dict:
     try:
         async with rubbergod_session.get(url) as resp:
             response = await resp.json()
-            if "error" in response:
-                raise ApiError(response["error"])
+            if resp.status != 200:
+                raise ApiError(response.get("msg", MessagesCZ.nasa_image_error))
             return response
     except (aiohttp.ClientConnectorError, asyncio.exceptions.TimeoutError) as error:
         raise ApiError(str(error))


### PR DESCRIPTION
## Summary
- `nasa_daily_image` checked `if "error" in response` to detect failures from the `apod-api` microservice, but that service's error bodies are shaped `{"code": ..., "msg": ...}` (see [apod-api application.py `_abort()`](https://github.com/vutfitdiscord/apod-api/blob/main/application.py)) and never contain an `"error"` key.
- As a result, error responses (e.g. HTTP 500 `Internal Service Error`) were passed through as if successful, and `create_nasa_embed` later crashed with `KeyError: 'date'` when building the embed.
- Reproduced by running the `apod-api` container directly: requesting today's APOD (`GET /v1/apod`) currently 500s with `Date not found in soup data.` (an upstream scraper issue in `apod-api` itself, not fixable here), and the response body is `{"code":500,"msg":"Internal Service Error","service_version":"v1"}` — exactly the shape that slipped past the old check.
- Fix: detect errors via `resp.status != 200` and surface `response["msg"]` (falling back to the existing `MessagesCZ.nasa_image_error`) via `ApiError`, which is already handled globally and shown to the user gracefully.

## Test plan
- [x] Ran the `apod-api` image locally (`ghcr.io/vutfitdiscord/apod-api:latest`) and confirmed error responses (500 on today's date, 400 on out-of-range dates) lack an `"error"` key
- [x] Confirmed valid dates still return `200` with the full payload, unaffected by this change
- [x] `pre-commit` (ruff, mypy, codespell) passes