### PR TITLE
fix: guard against non-JSON error bodies in NASA APOD fetch

### DIFF
--- a/cogs/info/features.py
+++ b/cogs/info/features.py
@@ -47,10 +47,14 @@ async def nasa_daily_image(rubbergod_session: aiohttp.ClientSession) -> dict:
     url = "http://nasa-api:5000/v1/apod"
     try:
         async with rubbergod_session.get(url) as resp:
-            response = await resp.json()
             if resp.status != 200:
-                raise ApiError(response.get("msg", MessagesCZ.nasa_image_error))
-            return response
+                try:
+                    error_response = await resp.json()
+                    message = error_response.get("msg", MessagesCZ.nasa_image_error)
+                except (aiohttp.ContentTypeError, ValueError):
+                    message = MessagesCZ.nasa_image_error
+                raise ApiError(message)
+            return await resp.json()
     except (aiohttp.ClientConnectorError, asyncio.exceptions.TimeoutError) as error:
         raise ApiError(str(error))
 


### PR DESCRIPTION
## Summary
Follow-up to #1333, which was merged before this review comment landed.

- `nasa_daily_image` called `await resp.json()` unconditionally before checking `resp.status`. If `apod-api` (or an intermediary/proxy) returns a non-200 response with a non-JSON or malformed body, `resp.json()` raises `aiohttp.ContentTypeError`/`ValueError`, which is not caught by the existing `except (aiohttp.ClientConnectorError, asyncio.exceptions.TimeoutError)` clause — bypassing the intended `ApiError` handling and crashing the command again.
- Fix: check `resp.status` first; only attempt to parse the error body as JSON for non-200 responses, wrapped in `try/except (aiohttp.ContentTypeError, ValueError)` falling back to `MessagesCZ.nasa_image_error` when the body can't be decoded.

## Test plan
- [x] Verified locally against a throwaway `aiohttp` test server serving: a plain-text 500 (non-JSON body), a JSON 500 (`{"code","msg"}` shape matching real `apod-api` errors), and a normal 200 — all three now behave correctly (clean `ApiError` for the first two, normal payload for the third), with no uncaught exceptions
- [x] `pre-commit` (ruff, mypy, codespell) passes